### PR TITLE
Gsa 67 display tpin on browser

### DIFF
--- a/src/client/src/app/modules/tournament/components/tournament-lobby/tournament-lobby.component.html
+++ b/src/client/src/app/modules/tournament/components/tournament-lobby/tournament-lobby.component.html
@@ -14,4 +14,8 @@
         </ng-template>
     </ul>
   </div>
+  <div class="pin-container">
+    <h3>Your Tournament Pin is: </h3>
+      <app-tournamentpin [tournamentPin]="tPin">  </app-tournamentpin>
+  </div>
 </div>

--- a/src/client/src/app/modules/tournament/components/tournament-lobby/tournament-lobby.component.ts
+++ b/src/client/src/app/modules/tournament/components/tournament-lobby/tournament-lobby.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
 import { SocketService } from 'src/app/services/socket.service';
 import { AppState } from 'src/app/store';
 import { loggedInSelector } from 'src/app/store/user/user.selectors';
@@ -15,6 +16,7 @@ export class TournamentLobbyComponent implements OnInit {
 
   guestPlayer!: string
   loggedIn: User | null = null
+  tPin: string | undefined
 
   constructor(private socketService: SocketService, private store: Store<AppState>) {
     this.store.select(loggedInSelector).subscribe(data => this.loggedIn = data)
@@ -22,7 +24,10 @@ export class TournamentLobbyComponent implements OnInit {
    }
 
   ngOnInit(): void {
-
+    this.tPin = this.socketService.tPin
+    console.log(this.tPin)
   }
+
+
 
 }

--- a/src/client/src/app/modules/tournament/presentation/tournamentpin/tournamentpin.component.html
+++ b/src/client/src/app/modules/tournament/presentation/tournamentpin/tournamentpin.component.html
@@ -1,0 +1,1 @@
+{{ tournamentPin }}

--- a/src/client/src/app/modules/tournament/presentation/tournamentpin/tournamentpin.component.spec.ts
+++ b/src/client/src/app/modules/tournament/presentation/tournamentpin/tournamentpin.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TournamentpinComponent } from './tournamentpin.component';
+
+describe('TournamentpinComponent', () => {
+  let component: TournamentpinComponent;
+  let fixture: ComponentFixture<TournamentpinComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TournamentpinComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TournamentpinComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/client/src/app/modules/tournament/presentation/tournamentpin/tournamentpin.component.ts
+++ b/src/client/src/app/modules/tournament/presentation/tournamentpin/tournamentpin.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-tournamentpin',
+  templateUrl: './tournamentpin.component.html',
+  styleUrls: ['./tournamentpin.component.scss']
+})
+export class TournamentpinComponent implements OnInit {
+@Input() tournamentPin: string | undefined
+
+  constructor() { }
+
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/client/src/app/modules/tournament/tournament.module.ts
+++ b/src/client/src/app/modules/tournament/tournament.module.ts
@@ -4,12 +4,14 @@ import { CommonModule } from '@angular/common';
 import { TournamentRoutingModule } from './tournament-routing.module';
 import { TournamentComponent } from './components/tournament/tournament.component';
 import { TournamentLobbyComponent } from './components/tournament-lobby/tournament-lobby.component';
+import { TournamentpinComponent } from 'src/app/modules/tournament/presentation/tournamentpin/tournamentpin.component';
 
 
 @NgModule({
   declarations: [
     TournamentComponent,
-    TournamentLobbyComponent
+    TournamentLobbyComponent,
+    TournamentpinComponent,
   ],
   imports: [
     CommonModule,

--- a/src/client/src/app/services/socket.service.ts
+++ b/src/client/src/app/services/socket.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Socket } from 'ngx-socket-io';
-import { map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -9,6 +8,8 @@ import { map } from 'rxjs/operators';
 export class SocketService {
 
   public sID!: string
+//  tPin?: Observable<string | null>
+  tPin: string | undefined
   // public sid$ = this.socket.fromEvent('connect').pipe(map(() => this.socket.ioSocket.id))
 
   constructor(private socket: Socket, private router: Router) {
@@ -22,14 +23,27 @@ export class SocketService {
           this.sID = 'guest' + this.sID.substring(5,12).toLowerCase()
         }
     })
+
   }
 
   createTournament(){
-    this.router.navigate(['/tournament/lobby'])
-    this.socket.emit('create-tournament', this.socket.ioSocket.id)
-    this.socket.on('generate tournament pin', (data :string) => {
-      console.log('Here is your tournament Pin', data)
+    this.socket.emit('create-tournament', this.socket.ioSocket.id, (data:any) => {
+      this.tPin = data
+      this.router.navigate(['/tournament/lobby'])
     })
+
+
+    // this.socket.on('generate tournament pin', (data:string)  => {
+    //   this.tPin = data
+    //   console.log('Pin received: ', this.tPin)
+    // })
+
+
+    // this.socket.on('generate tournament pin',(data: any )=> {
+    //   console.log('Here is your tournament Pin', data)
+    //   this.tPin = data
+
+    // })
   }
 }
 

--- a/src/server/helpers/socket.helper.ts
+++ b/src/server/helpers/socket.helper.ts
@@ -1,7 +1,5 @@
 
 const generateTournamentPin = () => {
-    let tPin = Math.floor(Math.random() * 10000)
-    return tPin
+    return (Math.random() * 100000).toString(32).substring(5, 10)  
 }
-
 export { generateTournamentPin }

--- a/src/server/sockets.ts
+++ b/src/server/sockets.ts
@@ -15,18 +15,20 @@ const tournamentPool: any = {
 export default io.on("connection", (socket) => {
     console.log("user connected, ", socket.id)
 
-    socket.on('create-tournament', () => {
+    socket.on('create-tournament', (socketID,cb) => {
+
       let tPin = generateTournamentPin()
       let joinedPlayers: any
-      let tournamentKey  = tPin.toString()
-      socket.emit('generate tournament pin', {tournamentPin: tPin })
-      socket.join(tournamentKey)
+      cb(tPin);
+      socket.join(tPin)
 
-          if ( tournamentPool[tournamentKey] == undefined){
-            joinedPlayers = new Array<string>(socket.id)
+          if (tournamentPool[tPin] == undefined){
+            joinedPlayers = new Array(socket.id)
             tournamentPool[tPin] = joinedPlayers
-          }
+          } 
+
           console.log(tournamentPool)
+
     })
   
     socket.on("disconnect", () => {


### PR DESCRIPTION
## Changes
1. Refactored some functions on both client and server as race condition is happening again.
2. Tournament Pin should be displayed on the player's browser 

## Purpose
The player should be able to see the tournament pin on the browser so anyone can join

## Approach
When a player creates a tournament for the first time,  a pin does not appear on the browser, but after going back to the last window and clicking the create tournament button, the pin appears on the browser. So a race condition happens again. To solve the problem, instead of implementing an observable (which also works), a presentation component named 'Tournamentpin' was generated. Since it is a child component of the Tournament lobby page, I have to inject the @Input decorator and call tPin from the socket service, inject the template in the tournament lobby component, and data-bind it. Also, some functions have been modified to tell the client that it should only navigate to the lobby page if a pin has been generated.

## Learning
with the help of Vinson and Aman (on using observables)

Closes #67 
