### PR TITLE
Gsa 76 game info save db

### DIFF
--- a/src/server/routes/api.routes.ts
+++ b/src/server/routes/api.routes.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response, NextFunction } from 'express';
+import { gameRouter } from './game.route.js';
 import { imageRouter } from './image.route.js';
 import { userRouter } from './user.route.js';
 
@@ -6,6 +7,7 @@ export const apiRouter = express.Router();
 
 apiRouter.use('/', userRouter);
 apiRouter.use('/', imageRouter);
+apiRouter.use('/', gameRouter);
 
 
 apiRouter.use((req,res, next) => {

--- a/src/server/routes/game.route.ts
+++ b/src/server/routes/game.route.ts
@@ -1,0 +1,44 @@
+import express from 'express';
+import { Player } from '../../shared/models/player.model.js';
+import { GameModel } from '../schemas/game.schema.js';
+import { UserModel } from '../schemas/user.schema.js';
+
+const gameRouter = express.Router();
+
+
+gameRouter.get('/game-info-player-vs-computer', function(req,res){
+    GameModel.find()
+    .then(info => {
+        res.json({info})
+    })
+    .catch(err => {
+        res.status(501).json({Error: err})
+    })
+})
+
+gameRouter.post('/game-info-player-vs-computer/:id', async function(req,res){
+    const id = req.params.id
+    const player = await UserModel.findOne({_id: id}, '-password -profilePic')
+
+        const game = new GameModel({
+            date: new Date(),
+            players: [player]
+        })
+
+        const computerId = await UserModel.findById({_id: '626e11e319e8267d756e8802'}) 
+
+        game.save()
+        .then(data => {
+
+            //save computer's object Id 
+            data!.players!.push(computerId!.id)  
+            game.save()
+            res.json({data})
+        })
+        .catch(err => res.status(500).json({Error: err}))
+
+})
+
+
+
+export { gameRouter }

--- a/src/shared/models/game.model.ts
+++ b/src/shared/models/game.model.ts
@@ -3,7 +3,7 @@ import type { User } from '../models/user.model';
 
 export interface Game {
     date: Date,
-    players: [type: mongoose.Types.ObjectId | User],
-    winner: {type: mongoose.Types.ObjectId | User},
+    players?: [{type: mongoose.Types.ObjectId | User}],
+    winner?: {type: mongoose.Types.ObjectId | User},
     _id: string,
 }


### PR DESCRIPTION
## Changes
1. Add get and post queries to save game info when the player chooses to play against the computer
2. Create an Object Id for 'Computer' in db.

## Purpose
Add API queries to save the game info in DB if the player chooses to play against the computer.

## Approach
It might not be a good practice but I passed the player's Object Id as params. This specific api post route will only work if the player is logged in. Validation might need to be handled on the front end first.

## Learning
-from a personal project 

Closes #76
